### PR TITLE
1.1.0 Release, salt update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,13 +24,12 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: go to password-generator
-        run: cd $GITHUB_WORKSPACE/password-generator
+        run: cd $GITHUB_WORKSPACE
 
-      - name: test password-generator
-        run: cargo test --verbose
-
-      - name: compile password-generator wasm library
+      - name: compile and test password-generator
         run: |
+          cd password-generator
+          cargo test --verbose
           cargo install wasm-pack
           wasm-pack build --target bundler
           cd pkg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,12 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: go to password-generator
-        run: cd $GITHUB_WORKSPACE/password-generator
+        run: cd $GITHUB_WORKSPACE
 
-      - name: test password-generator
-        run: cargo test --verbose
-
-      - name: compile password-generator wasm library
+      - name: compile and test password-generator
         run: |
+          cd password-generator
+          cargo test --verbose
           cargo install wasm-pack
           wasm-pack build --target bundler
           cd pkg

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "passworphobia-app",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1726,7 +1726,7 @@ dependencies = [
 
 [[package]]
 name = "passworphobia-app"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "passworphobia-app"
-version = "1.0.1"
+version = "1.1.0"
 description = "A passwordless password manager"
 authors = ["Stepan Malchenko", "Anita Eruste"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Passworphobia",
-    "version": "1.0.1"
+    "version": "1.1.0"
   },
   "tauri": {
     "allowlist": {

--- a/src/store.ts
+++ b/src/store.ts
@@ -16,6 +16,7 @@ export const SYMBOLS: string = "!\"#$%&'()*+,-./:;<=>?@[]\\^_`{}|~";
 
 export const SIZE_FACTOR: number = 14;
 export const DEFAULT: number = 3;
+export const SALT_SIZE: number = 48;
 
 export let appState = writable(AppState.Lock);
 


### PR DESCRIPTION
A little app update concerning automatic salt generation. Before we used 64 long hex IDS, which we don't believe are suitable and secure enough for actually unique salts. We switched them to 64 long base64 strings, which are drastically way more unique.